### PR TITLE
fix: revert deletion in config that broke page urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,14 @@ exclude:
 defaults:
   -
     scope:
+      path: ""
+      type: "pages"
+    values:
+      permalink: "/:basename"
+      layout: "page"
+      sidebar: main
+  -
+    scope:
       path: "pages/lifecycle"
     values:
       type: "pages"


### PR DESCRIPTION
This PR fixes a bug that was introduced in #82 , which lead to the URLs not being mapped correctly to pages.