### PR TITLE
chore: rename Acknowledgement to Contact in footer.yml

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -10,7 +10,7 @@ columns:
     children:
       - url_text: Contributors
         url: /contributors
-      - url_text: Acknowledgments
+      - url_text: Contact
         url: /contact
       - url_text: Contribute
         url: "pages/contribute"


### PR DESCRIPTION
Acknowledgement will be in the About page, corrects that click on former 'Acknowledgement' leads to Contact page