### PR TITLE
Update editorial_board_guide.md

### DIFF
--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -139,7 +139,7 @@ Alexia Cordona:
 {% include callout.html type="important" content="Make sure that the name in the yaml file is identically the same as the one used in the metadata of the page." %}
 
 
-## Adding an institution, infrastructure, project or funder
+<!-- ## Adding an institution, infrastructure, project or funder
 
 Institutions, projects, funders and infrastructures are listed in the [affiliations.yml](https://github.com/elixir-europe-training/ELIXIR-Training-SPLASH/blob/master/_data/affiliations.yaml) file. The info in this file is used on the support page in the about section, but also for the affiliations in tool assembly pages. Make sure you make use of the same name in those assembly pages. The yaml file has following syntax:
 ```yaml
@@ -173,7 +173,7 @@ related_pages:
    your_domain: [page_id1, page_id2]
    tool_assembly: [page_id1, page_id2]
   ``` 
-
+-->
 
 ### Page ID
 

--- a/pages/contribute/editors_checklist.md
+++ b/pages/contribute/editors_checklist.md
@@ -11,11 +11,10 @@ summary: Checklist for editors before approving and merging a pull request ({% g
    * unique `page_id` ([List of page IDs](website_overview))
    * `contributors`
    * `related_pages` ([Related pages](editorial_board_guide.html#related-pages))
-   * `training`
    * `search_exclude` must be deleted
    * `description`
    * `affiliation`
-   * `coordinators`(only used in national pages + they must be listed as `contributors` as well)
+   * `coordinators`(only used in resource pages + they must be listed as `contributors` as well)
    * `resources`
 5. The content is conform to ELIXIR Training SPLASH scope, [style](style_guide) and templates.
 6. There are no [copyright](copyright) issues related to the content of the page.

--- a/pages/contribute/how_to_contribute.md
+++ b/pages/contribute/how_to_contribute.md
@@ -8,7 +8,7 @@ Everyone is welcome to contribute to this site, and we've tried to make it as ea
 
 * **If you are not familiar with Git** but want to give it a try on GitHub: follow [our step-by-step instructions](github_way) (no technical knowledge required!).
 * **If you are familiar with Git**: fork the repo and create a pull request (see our [instructions](working_with_git)).
-* **If you just want to make a quick suggestion**: submit your comments/suggestions using an issue as deescribed below.
+* **If you just want to make a quick suggestion**: submit your comments/suggestions using an issue as described below.
 
 ## Contributor responsibilities
 

--- a/pages/lifecycle/deliver.md
+++ b/pages/lifecycle/deliver.md
@@ -3,3 +3,5 @@ title: Deliver
 ---
 
 Donec finibus ultrices placerat. Aliquam sagittis massa lorem, id ultricies felis bibendum a. Proin et sem in sem maximus commodo et nec sem. Nullam sit amet euismod purus. Donec feugiat et enim a pharetra. In efficitur luctus erat sit amet volutpat. In maximus nunc vitae tristique tincidunt. Donec aliquam in ante ac posuere.
+
+test


### PR DESCRIPTION
Currently there is no affiliations file in the main branch of the repository. If we don't use affiliations it might be better to remove this section. If we plan to use we should remove "tool assembly" and use the corresponding SPLASH terminology (resources?)