### PR TITLE
168 correct numbers on the main page to align with elixir europe website

### DIFF
--- a/_data/index/numbers.yml
+++ b/_data/index/numbers.yml
@@ -7,16 +7,16 @@
   icon: fas fa-person-chalkboard
 
 - title: Courses
-  number: 1700+
+  number: 3194
   color: blue
   icon: fas fa-book
 
 - title: Trainees
-  number: 38700+
+  number: 41346
   color: red
   icon: fas fa-database
 
 - title: Countries
-  number: 99+
+  number: 100
   color: green
   icon: fas fa-chart-simple

--- a/_data/index/numbers.yml
+++ b/_data/index/numbers.yml
@@ -7,16 +7,16 @@
   icon: fas fa-person-chalkboard
 
 - title: Courses
-  number: 1999
+  number: 1700+
   color: blue
   icon: fas fa-book
 
 - title: Trainees
-  number: 41346
+  number: 38700+
   color: red
   icon: fas fa-database
 
 - title: Countries
-  number: 62
+  number: 99+
   color: green
   icon: fas fa-chart-simple


### PR DESCRIPTION
Maybe numbers on the ELIXIR web page are quite old? From TeSS, filtering on event type (workshops and courses), nodes (all represented) and date < 31/12/2024, I got 3194 events => updated to that number