### PR TITLE
Fix editorial board cards and add git ids

### DIFF
--- a/_data/CONTRIBUTORS.yml
+++ b/_data/CONTRIBUTORS.yml
@@ -11,6 +11,7 @@ Ajay Mishra:
     role: 
 
 Alexander Botzki:
+    git: abotzki
     affiliation: VIB Training & Conferences
     node: BE
     orcid: 0000-0001-6691-4233 
@@ -20,6 +21,7 @@ Alexandra Holinski:
     role:
 
 Alexia Cardona:
+    git: ac812
     affiliation: University of Cambridge
     email: ac812@cam.ac.uk
     node: UK
@@ -50,6 +52,7 @@ Bérénice Batut:
     role: 
 
 Bruna Piereck:
+    git: bpiereck
     affiliation: VIB Training & Conferences
     email: bruna.piereckmoura@vib.be
     node: BE
@@ -92,6 +95,7 @@ Dayane Araújo:
     role: 
 
 Elin Kronander:
+    git: elinkronander
     affiliation: NBIS National Bioinformatics Infrastructure Sweden
     node: SE
     role : editor
@@ -123,6 +127,7 @@ Fred de Lamotte:
     role: 
 
 Geert van Geest:
+    git: GeertvanGeest
     affiliation: SIB Swiss Institute of Bioinformatics
     email: geert.vangeest@sib.swiss
     node: CH

--- a/pages/about/editorial_board.md
+++ b/pages/about/editorial_board.md
@@ -4,7 +4,7 @@ title: Editorial board
 
 ## Meet the editorial board members
 
-{% include contributor-carousel-selection.html custom="Alexia Cardona, Elin Kronander, Bruna Piereck, Alexander Botzki, Geert Van Geest"%}
+{% include contributor-carousel-selection.html custom="Alexia Cardona, Elin Kronander, Bruna Piereck, Alexander Botzki, Geert van Geest"%}
 
 ## Join as editorial board member
 


### PR DESCRIPTION
The editorial board cards are fixe. 
I also added git ids for the editorial board members to have pictures/avatars shown instead of just letters. 