### PR TITLE
fixes #247

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,6 @@ defaults:
     scope:
       path: "pages/lifecycle"
     values:
-      type: "pages"
       sidebar: lifecycle
   -
     scope:


### PR DESCRIPTION
Removes specific 'pages' type of TLC - so it doesn't show the word 'pages' anymore at the beginning of every page. 