### PR TITLE
Separate trainer development from general training preparation

### DIFF
--- a/pages/lifecycle/deliver.md
+++ b/pages/lifecycle/deliver.md
@@ -9,20 +9,21 @@ From a pedagogical perspective, communicating with participants by providing and
 
 Logistical tasks include selecting a venue or technical platform, ensuring accessibility and technical setup, announcements and registering participants, arranging catering for in-person events, creating and organizing documents such as surveys and prints, in addition to the digital resources storage and sharing strategies.
 
-## What are the pedagogical aspects?
+## What are the pedagogical and community aspects?
 
 **Developing as a trainer**:
-So you are supposed to run a training. Maybe this is your idea, maybe your employer asked you to do this. If you are new to the topic of teaching, or have been teaching in other contexts before, you may want to take a train the trainer workshop. But also if you are an experienced trainer, it maybe worth to join a train the trainer session once in a while to catch up and connect to the trainer community. 
+So you are supposed to run a training. Maybe this is your idea, maybe your employer asked you to do this. If you are new to the topic of teaching, or have been teaching in other contexts before, you may want to take a train the trainer workshop. But also if you are an experienced trainer, it maybe worth to join a train the trainer session once in a while to catch up on latest tools and connect to the trainer community. 
 
 **Before the training event**:
 * Participant selection assessment: Define criteria for prioritization and assessment of trainees application in order to select participants that can benefit the most from the training and training format.
 * Didactics: Align strategy based on the pre-course survey and needed resources to enable and facilitate learning
-* Accessibility: Check with participants and trainers if they have special needs (dyslexia, color blindness, etc …)
-* Trainer setup: It is preferable to teach in partnership, that allows for more support to trainees. However you must consider the delivery format and learning experiences to define an ideal number of trainers and trainees. Conduct a pre-course meeting with collaborators to align expectations and address any questions, define roles, align time, didactic strategies, ...
+* Accessibility: Check with participants and trainers if they have special needs (access, dyslexia, color blindness, etc …)
+* Trainer setup: It is preferable to teach in partnership, that allows for more support to trainees. However you must consider the delivery format and learning experiences to define an ideal number of trainers and trainees. Conduct a pre-course meeting with collaborators to align expectations and address any questions, define roles, align time, didactic strategies, ..
+* Material update and testing: If you have taught the training before or you are reusing someone elses training materials, make sure to go through it before the event, check for broken links, ooutdated information and test run all exercises on a "learner-like" platform.
   
 **During the training event**:
-* Ice breaker: Introduce trainers and start with an ice breaker activity to enhance engagement.
-* Interactive: Deliver course content in an interactive and variable manner to increase learning opportunities..
+* Ice breaker: Introduce trainers and start with an ice breaker activity to enhance engagement. Facilitate also participant interaction among each other. 
+* Interactive: Deliver course content in an interactive and variable manner to increase learning opportunities.
 * Adapt: Monitor the participant engagement and address questions promptly and adapt instructions and content to meet learner needs. 
 * Practical Exercises: Provide clear written instructions for hands-on exercises and offer guidance and support to participants as needed.
 * Assessments: Conduct formative or summative assessments, such as quizzes, learner reflections or assignments, to evaluate learning. 
@@ -32,18 +33,14 @@ So you are supposed to run a training. Maybe this is your idea, maybe your emplo
 
 ## What are the logistical aspects?
 
+Some logistical aspects differ for in-person, online and hybrid events. We try to mark where there might be differences.  
 This is not an exhaustive listing of items to consider.
 
-**Before the training event**:
-
-*Venue and Catering*:
-* Venue: Secure a suitable venue with appropriate facilities. Visit the venue to try out the technical set-up, arrange access cards and signs to find the room etc.
-* Accessibility: Check with participants and trainers if they have special needs.
-* Catering: Arrange catering services, considering dietary requirements and preferences.
+### General considerations
 
 *Registrations*
 * Registration: Set up a registration process that collects information needed to select participants or define clearly that this is a “first come - first serve” setup.
-Consider collecting demographic data for future analysis. Make sure to protect sensitive data and participant information.
+Consider collecting demographic data for future analysis. Make sure to protect sensitive data and participant information. Hybrid/in-person events: Ask for attendance mode and dietary restrictions if needed.
 * Course Announcement: Publish a course announcement on relevant platforms (e.g., [TeSS](https://tess.elixir-europe.org/), newsletters, social media, email) including the following information:
   * Short description
   * Learning Objectives
@@ -57,46 +54,71 @@ Consider collecting demographic data for future analysis. Make sure to protect s
 * Participant selection and assessment: When applicable, review the registration form and select participants based on their prior knowledge and skills and the criteria.
  
 *Course technical resources*:
-
-Technical considerations for online or hybrid events:
+* Compute resources: Prepare access to compute resources, learning management systems, notebooks, …
+* Prepare any non-digital resource
+* Feedback: Prepare the event-specific feedback survey to be shared afterwards with participants as well as a trainer’s reflection document for the trainers (and observers, if any).
+In addition for online/hybrid events: 
 * Selecting the meeting platform: For example, Zoom, WebEx, Teams
 * Decide on interaction procedure and prepare: E.g. via meeting platform chat, separate collaborative document (HackMD, Etherpad, GoogleDocs etc), using a chat platform (Slack, Zulip, RocketChat etc)
 * Online helper: Breakout rooms, technical checks for online resources, setup and test audio and screensharing
-* Compute resources: Prepare access to compute resources, learning management systems, notebooks, …
-* Prepare any non-digital resource
-* Feedback: Prepare the event-specific feedback survey to be shared afterwards with participants as well as a trainer’s reflection document for the trainers (and observers, if any). 
 
+
+### Before the training event
+
+For in-person event: *Venue and Catering*:
+* Venue: Secure a suitable venue with appropriate facilities. Visit the venue to try out the technical set-up, arrange access cards and signs to find the room etc.
+* Accessibility: Check with participants and trainers if they have special needs.
+* Catering: Arrange catering services, considering dietary requirements and preferences.
 
 *Communication with participants*:
 Participant Preparation: Send pre-course information including:
   * Installation guidelines for required software. Consider offering a help-session the week before the event.
   * Pre-reading materials.
-  * Instructions for accessing online resources and virtual meeting platforms.
-  * Information on how to reach the venue.
+  * Instructions for accessing online resources and virtual meeting platforms for online/hybrid events. 
+  * Information on how to reach the venue for in-person events. 
   * The Code of Conduct for the event.
   * Pre-course survey (if applicable): getting information about expectations and previous knowledge
 
-*During the training event*:
+### During the training event
 
 **Onboarding and Welcome**: Welcome participants and introduce the course objectives, structure and practicalities (see below). Allow time to address any questions or concerns.
+* Introduction round (by voice or in collaborative notes) + Icebreaker
 * Course schedule
 * Code of Conduct
 * Attendance list
-* Safety/fire alarms
-* Restrooms and refreshments
-* Wifi
+* Certification requirements, if any
+* Support avialability; e.g by introducing available helpers/documents
+* Additional items for in-person/hybrid training:
+  * Safety/fire alarms
+  * Restrooms and refreshments
+  * Wifi
+* Additional items for online training:
+  * Communication and interaction options
+  * Use of breakoutrooms
 * **Breaks**: Always announce when a break is planned and happening and if there are any refreshments etc available. Possibly write somewhere visible, e.g. whiteboard, chat or collaborative notes so everyone knows when it is expected and when it ends.
 
-**After the training event**:
-* Certificates: Send certificates to eligible participants in individual emails or make it available in the registration system when applicable. Make sure you abide by the GDPR regulations.
+*Communication with participants*
+If the training is longer than one session, consider communicating a summary and preparations for the next session in between the sessions.
+
+
+### After the training event
 
 *Evaluation and Feedback*:
 * Distribute evaluation forms to gather feedback on the course content, delivery, and overall experience, Also ask trainers to make use of the trainer’s reflections document.
 * Continuous improvement: Invite trainers to a follow-up meeting to reflect on the delivery, discuss improvements and updates.
 
 *Communication with trainees*:
-* Include related trainings for communication
+* Include related training for communication
 * Inform if support/consultancy is available after training
+* Send certificates to eligible participants in individual emails or make it available in the registration system when applicable. Make sure you abide by the GDPR regulations.
+* Consider sending some suggested next steps for learners to apply and further develop their knowledge in the topic taught. You may also link to communities or conferences of the topic. If applicable, open the possibility for becoming a helper in a future iteration of the training. 
+
+*Communication with fellow trainers*:
+* Offer a trainer debrief, ask for example for people to share about "one thing that went well", "one thing that should be improved for next time".
+* Collect and share lessons learned about the training (if related to the materials, consider adding Issues for future improvements or add to instructor notes)
+* Share some general lessons learned with the broader training community, if applicable. 
+
+
 
 ## Related resources: 
 

--- a/pages/lifecycle/deliver.md
+++ b/pages/lifecycle/deliver.md
@@ -1,6 +1,6 @@
 ---
 title: Deliver
-contributors: [Mark Fernandes, Patricia Palagi, Bruna Piereck, Luciana Peixoto, Alexander Botzki, Alexia Cardona, Helena Schnitzer, Elin Kronander, Jeanne Wilbrandt, Geert van Geest]
+contributors: [Mark Fernandes, Patricia Palagi, Bruna Piereck, Luciana Peixoto, Alexander Botzki, Alexia Cardona, Helena Schnitzer, Elin Kronander, Jeanne Wilbrandt, Geert van Geest, Samantha Wittke]
 ---
 
 This stage encompasses both pedagogical, logistical and organization steps, with a primary focus on didactics. These tasks are divided into arrangements and planning required before, during, and after training delivery. Revisit the plan, design and develop outcomes and take into account decisions made during the previous stages when initiating delivery.

--- a/pages/lifecycle/deliver.md
+++ b/pages/lifecycle/deliver.md
@@ -38,22 +38,26 @@ This is not an exhaustive listing of items to consider.
 
 ### General considerations
 
-*Registrations*
-* Registration: Set up a registration process that collects information needed to select participants or define clearly that this is a “first come - first serve” setup.
+**Course announcement**
+Publish a course announcement on relevant platforms (e.g., [TeSS](https://tess.elixir-europe.org/), newsletters, social media, email) including the following information:
+* Short description
+* Learning Objectives
+* Target audience
+* Fee
+* Delivery mode
+* Dates and location
+* Prerequisites and eligibility
+* Related courses in learning path or curriculum
+* Funding/sponsors
+
+**Registration**
+Set up a registration process that collects information needed to select participants or define clearly that this is a “first come - first serve” setup.
 Consider collecting demographic data for future analysis. Make sure to protect sensitive data and participant information. Hybrid/in-person events: Ask for attendance mode and dietary restrictions if needed.
-* Course Announcement: Publish a course announcement on relevant platforms (e.g., [TeSS](https://tess.elixir-europe.org/), newsletters, social media, email) including the following information:
-  * Short description
-  * Learning Objectives
-  * Target audience
-  * Fee
-  * Delivery mode
-  * Dates and location
-  * Prerequisites and eligibility
-  * Related courses in learning path or curriculum
-  * Funding/sponsors
-* Participant selection and assessment: When applicable, review the registration form and select participants based on their prior knowledge and skills and the criteria.
+
+**Participant selection and assessment**
+If applicable, review the registration form and select participants based on their prior knowledge and skills and the criteria.
  
-*Course technical resources*:
+**Course technical resources**
 * Compute resources: Prepare access to compute resources, learning management systems, notebooks, …
 * Prepare any non-digital resource
 * Feedback: Prepare the event-specific feedback survey to be shared afterwards with participants as well as a trainer’s reflection document for the trainers (and observers, if any).
@@ -65,12 +69,12 @@ In addition for online/hybrid events:
 
 ### Before the training event
 
-For in-person event: *Venue and Catering*:
+For in-person event: **Venue and Catering**:
 * Venue: Secure a suitable venue with appropriate facilities. Visit the venue to try out the technical set-up, arrange access cards and signs to find the room etc.
 * Accessibility: Check with participants and trainers if they have special needs.
 * Catering: Arrange catering services, considering dietary requirements and preferences.
 
-*Communication with participants*:
+**Communication with participants**:
 Participant Preparation: Send pre-course information including:
   * Installation guidelines for required software. Consider offering a help-session the week before the event.
   * Pre-reading materials.
@@ -97,23 +101,23 @@ Participant Preparation: Send pre-course information including:
   * Use of breakoutrooms
 * **Breaks**: Always announce when a break is planned and happening and if there are any refreshments etc available. Possibly write somewhere visible, e.g. whiteboard, chat or collaborative notes so everyone knows when it is expected and when it ends.
 
-*Communication with participants*
+**Communication with participants**
 If the training is longer than one session, consider communicating a summary and preparations for the next session in between the sessions.
 
 
 ### After the training event
 
-*Evaluation and Feedback*:
+**Evaluation and Feedback**
 * Distribute evaluation forms to gather feedback on the course content, delivery, and overall experience, Also ask trainers to make use of the trainer’s reflections document.
 * Continuous improvement: Invite trainers to a follow-up meeting to reflect on the delivery, discuss improvements and updates.
 
-*Communication with trainees*:
+**Communication with trainees**
 * Include related training for communication
 * Inform if support/consultancy is available after training
 * Send certificates to eligible participants in individual emails or make it available in the registration system when applicable. Make sure you abide by the GDPR regulations.
 * Consider sending some suggested next steps for learners to apply and further develop their knowledge in the topic taught. You may also link to communities or conferences of the topic. If applicable, open the possibility for becoming a helper in a future iteration of the training. 
 
-*Communication with fellow trainers*:
+**Communication with fellow trainers**
 * Offer a trainer debrief, ask for example for people to share about "one thing that went well", "one thing that should be improved for next time".
 * Collect and share lessons learned about the training (if related to the materials, consider adding Issues for future improvements or add to instructor notes)
 * Share some general lessons learned with the broader training community, if applicable. 

--- a/pages/lifecycle/deliver.md
+++ b/pages/lifecycle/deliver.md
@@ -11,11 +11,13 @@ Logistical tasks include selecting a venue or technical platform, ensuring acces
 
 ## What are the pedagogical aspects?
 
+**Developing as a trainer**:
+So you are supposed to run a training. Maybe this is your idea, maybe your employer asked you to do this. If you are new to the topic of teaching, or have been teaching in other contexts before, you may want to take a train the trainer workshop. But also if you are an experienced trainer, it maybe worth to join a train the trainer session once in a while to catch up and connect to the trainer community. 
+
 **Before the training event**:
 * Participant selection assessment: Define criteria for prioritization and assessment of trainees application in order to select participants that can benefit the most from the training and training format.
 * Didactics: Align strategy based on the pre-course survey and needed resources to enable and facilitate learning
 * Accessibility: Check with participants and trainers if they have special needs (dyslexia, color blindness, etc …)
-* Trainer-the-trainer: When needed trainers must take the course in advance to update, improve or learn the theory of teaching and some strategies.
 * Trainer setup: It is preferable to teach in partnership, that allows for more support to trainees. However you must consider the delivery format and learning experiences to define an ideal number of trainers and trainees. Conduct a pre-course meeting with collaborators to align expectations and address any questions, define roles, align time, didactic strategies, ...
   
 **During the training event**:
@@ -57,21 +59,22 @@ Consider collecting demographic data for future analysis. Make sure to protect s
 *Course technical resources*:
 
 Technical considerations for online or hybrid events:
-* Selecting the platform: For example, Zoom, WebEx, Teams
-* Online helper: Breakout rooms, technical checks for online resources
-* Compute resources: Prepare access to compute resources, learning management systems, collaborative notes documents, notebooks, …
+* Selecting the meeting platform: For example, Zoom, WebEx, Teams
+* Decide on interaction procedure and prepare: E.g. via meeting platform chat, separate collaborative document (HackMD, Etherpad, GoogleDocs etc), using a chat platform (Slack, Zulip, RocketChat etc)
+* Online helper: Breakout rooms, technical checks for online resources, setup and test audio and screensharing
+* Compute resources: Prepare access to compute resources, learning management systems, notebooks, …
 * Prepare any non-digital resource
 * Feedback: Prepare the event-specific feedback survey to be shared afterwards with participants as well as a trainer’s reflection document for the trainers (and observers, if any). 
 
 
 *Communication with participants*:
-* Participant Preparation: Send pre-course information including:
-* Installation guidelines for required software. Consider offering a help-session the week before the event.
-* Pre-reading materials.
-* Instructions for accessing online resources and virtual meeting platforms.
-* Information on how to reach the venue.
-* The Code of Conduct for the event.
-* Pre-course survey (if applicable): getting information about expectations and previous knowledge
+Participant Preparation: Send pre-course information including:
+  * Installation guidelines for required software. Consider offering a help-session the week before the event.
+  * Pre-reading materials.
+  * Instructions for accessing online resources and virtual meeting platforms.
+  * Information on how to reach the venue.
+  * The Code of Conduct for the event.
+  * Pre-course survey (if applicable): getting information about expectations and previous knowledge
 
 *During the training event*:
 
@@ -82,7 +85,7 @@ Technical considerations for online or hybrid events:
 * Safety/fire alarms
 * Restrooms and refreshments
 * Wifi
-* **Breaks**: Always announce when a break is over and if there are any refreshments etc available. Possibly write somewhere visible so everyone knows when it is expected.
+* **Breaks**: Always announce when a break is planned and happening and if there are any refreshments etc available. Possibly write somewhere visible, e.g. whiteboard, chat or collaborative notes so everyone knows when it is expected and when it ends.
 
 **After the training event**:
 * Certificates: Send certificates to eligible participants in individual emails or make it available in the registration system when applicable. Make sure you abide by the GDPR regulations.


### PR DESCRIPTION
A suggestion to separate developing as a trainer from the rest of delivery. 
Happy to hear what you think.

I also tried to make it more clear when something is for in-person events, online events or hybrid events. 

I think there would also be space for some more hints/considerations for the sometimes dreaded hybrid events (but time ran out for now)

Leaving this still in draft because it is not quite done yet, but I am keen to hear what you think so far. 



Related #15  and #241 