### PR TITLE
adds baseurl to card hyperlinks

### DIFF
--- a/_includes/ttt-community-cards.html
+++ b/_includes/ttt-community-cards.html
@@ -11,7 +11,7 @@
             <div class="card-body text-center p-3">
               {% if member.image %}
               <div class="mb-3">
-                <img src="{{ site.baseurl }}{{ member.image }}" alt="{{ member.title }}" class="rounded-circle img-fluid" style="width: 100px; height: 100px; object-fit: cover;">
+                <img src="{{ member.image }}" alt="{{ member.title }}" class="rounded-circle img-fluid" style="width: 100px; height: 100px; object-fit: cover;">
               </div>
               {% else %}
               <div class="mb-3">

--- a/_includes/ttt-modules-cards.html
+++ b/_includes/ttt-modules-cards.html
@@ -10,7 +10,7 @@
         <a href="{{ site.baseurl }}{{ module.url }}" class="text-decoration-none text-dark">
           <div class="card-body text-center p-4">
             <div class="mb-3">
-              <img src="{{ site.baseurl }}/assets/img/icons/Education-orange.png" alt="{{ module.title }}" class="module-icon">
+              <img src="/assets/img/icons/Education-orange.png" alt="{{ module.title }}" class="module-icon">
             </div>
             <h5 class="card-title mb-2" style="color: #4F1C46; font-size: 1rem; font-weight: 600;">{{ module.title }}</h5>
             {% if module.description %}


### PR DESCRIPTION
Fixes broken links on the TtT page. 

@khaled196 : the baseurl was missing in cards, therefore they redirected to the root of the domain. 