### PR TITLE
Remove contributors section from resources

### DIFF
--- a/_data/CONTRIBUTORS.yml
+++ b/_data/CONTRIBUTORS.yml
@@ -402,6 +402,12 @@ Nicola Soranzo:
     git: nsoranzo 
     role: 
 
+Nina Norgren:
+    node: SE    
+    orcid:0000-0002-3823-1555
+    git: ninanorgren
+    role: 
+
 Olivier Sand:
     node: no
     orcid: 

--- a/_data/CONTRIBUTORS.yml
+++ b/_data/CONTRIBUTORS.yml
@@ -404,7 +404,7 @@ Nicola Soranzo:
 
 Nina Norgren:
     node: SE    
-    orcid:0000-0002-3823-1555
+    orcid: 0000-0002-3823-1555
     git: ninanorgren
     role: 
 

--- a/_layouts/resource_page.html
+++ b/_layouts/resource_page.html
@@ -183,7 +183,6 @@ layout: default
         {% include resource-table-all.html tag=page.page_id %}
         {%- endif %}
         {% include affiliation-tiles-page.html %}
-        {% include contributor-minitiles-page.html %}
         {%- if site.theme_variables.github_buttons.position == "bottom" %}
         <div id="github-buttons-wrapper" class="d-flex mt-5">
         {% include github-buttons.html %}

--- a/pages/resources/TEMPLATE_resource_page.md
+++ b/pages/resources/TEMPLATE_resource_page.md
@@ -13,8 +13,8 @@ objective: |
 
   * markdown
   * example 
-contributors: [Alexander Botzki, Mihail Anton, Alexia Cardona]
-coordinators: [Alexia Cardona]
+
+contributor: [Alexia Cardona] # List of main responsible for maintainig the reseource on SPLASH
 contacts:
   - name: Contact Train the Trainers team
     email: jona.doe@example.org

--- a/pages/resources/elearning.md
+++ b/pages/resources/elearning.md
@@ -9,15 +9,8 @@ objective: |
   * Exchange and recommend best practices for e-learning material creation and implementation (e.g., interactivity, accessibility, maintainability, open access)
   * Define and improve curation processes for e-learning content, especially for inclusion in the TeSS training registry
   * Participate in collaborative development and sharing of e-learning resources across the ELIXIR network
+
 contributors:
-  - Ajay Mishra
-  - Alexander Botzki
-  - Daniel Wibberg
-  - Marko Vidak
-  - Monique Zahn
-  - Nadja Zlender
-  - Olivier Sand
-coordinators:
   - Alexander Botzki
 contacts:
   - name: Alexander Botzki

--- a/pages/resources/elixir-lesson-template.md
+++ b/pages/resources/elixir-lesson-template.md
@@ -12,11 +12,6 @@ tags: [elixir, develop, template]
 
 contributors:
   - Alexia Cardona
-  - Elin Kronander
-  - Geert van Geest
-  - Jose Alejandro Romero Herrera
-coordinators:
-  - Alexia Cardona
   - Geert van Geest
 contacts:
   - name: Geert van Geest

--- a/pages/resources/fair-training-handbook.md
+++ b/pages/resources/fair-training-handbook.md
@@ -17,14 +17,14 @@ objective: |
 tags: [elixir, design, develop, fair-training, train-the-trainer]
 
 
-coordinators:
+contributors:
   - Bruna Piereck
   - Geert van Geest
 
 #OPTIONAL FIELDS
 tags: [elixir, fair-training, design, develop]
 
-contributors:
+contacts:
   - name: Bruna Piereck
     email: bruna.piereckmoura@vib.be
   - name: Geert van Geest

--- a/pages/resources/fair-training-handbook.md
+++ b/pages/resources/fair-training-handbook.md
@@ -16,56 +16,6 @@ objective: |
 
 tags: [elixir, design, develop, fair-training, train-the-trainer]
 
-contributors:
-  - Alexandra Holinski
-  - Alexia Cardona
-  - Alice Matimba
-  - Allegra Via
-  - Anastasios Anastasios Papaioannou
-  - Anna Swan
-  - Bruna Piereck
-  - Celia van Gelder
-  - Daniel Thomas Lopez
-  - Daniel Wibberg
-  - Fred de Lamotte
-  - Geert van Geest
-  - Helen Clare
-  - Helena Schnitzer
-  - Hélène Chiapello
-  - Iryna Kuchma
-  - Iulianna van der Lek
-  - Kathryn Unsworth
-  - Krzysztof Poterlowicz
-  - Leyla Jael Castro
-  - Lisanna Paladin
-  - Loredana Le Pera
-  - Lucie Khamvongsa-Charbonnier
-  - Maja Rey
-  - Marcela Davila
-  - Maria Doyle
-  - Marta Lloret
-  - Melissa Burke
-  - Michelle D Brazas
-  - Monique Zahn
-  - Nazeefa Fatima
-  - Nicola Mulder
-  - Olivier Sand
-  - Patricia Carvajal Lopez
-  - Patricia Palagi
-  - Rachel Berkson
-  - Renato Alves
-  - Roland Krause
-  - Russell Schwartz
-  - Sara El-Gebali
-  - Sarah Morgan
-  - Saskia Hiltemann
-  - Shaun Aron
-  - Steven Morgan
-  - Suzanne Duce
-  - Tarcisio Mendes de Farias
-  - Vera Matser
-  - Verena Ras
-  - Wai Keat Yam
 
 coordinators:
   - Bruna Piereck
@@ -74,7 +24,7 @@ coordinators:
 #OPTIONAL FIELDS
 tags: [elixir, fair-training, design, develop]
 
-contacts:
+contributors:
   - name: Bruna Piereck
     email: bruna.piereckmoura@vib.be
   - name: Geert van Geest

--- a/pages/resources/fair-training-working-group.md
+++ b/pages/resources/fair-training-working-group.md
@@ -18,39 +18,6 @@ objective: |
 tags: [elixir, design, develop, fair-training, community]
     
 contributors:
-  - Alexandra Holinski
-  - Alexia Cardona
-  - Allegra Via
-  - Beatriz Serrano-Solano
-  - Branka Franicevic
-  - Bérénice Batut
-  - Celia van Gelder
-  - Chris Child
-  - David Lloyd
-  - Dayane Araújo
-  - Fotis Psomopoulos
-  - Fred de Lamotte
-  - Geert van Geest
-  - Helen Clare
-  - Helena Schnitzer
-  - Ines Chaves
-  - Jessica Lindvall
-  - Katharina Heil
-  - Krzysztof Poterlowicz
-  - Leyla Jael Castro
-  - Lisanna Paladin
-  - Loredana Le Pera
-  - Manthos Pitoulias
-  - Melissa Burke
-  - Monique Zahn
-  - Olivier Sand
-  - Patricia Palagi
-  - Pedro Fernandes
-  - Roland Krause
-  - Sara Morsey
-  - Xènia Pérez Sitjà
-
-coordinators:
   - Geert Van Geest
   - Sara Morsey
   - Zoi Litou

--- a/pages/resources/galaxy-training.md
+++ b/pages/resources/galaxy-training.md
@@ -21,22 +21,6 @@ contributors:
   - Saskia Hiltemann
   - Bérénice Batut
   - Helena Rasche
-  - Björn Grüning
-  - Solenne Correard
-  - Fotis Psomopoulos
-  - Anthony Bretaudeau
-  - Hans-Rudolf Hotz
-  - Martin Čech
-  - Nicola Soranzo
-  - Pavankumar Videm
-  - Krzysztof Poterlowicz
-  - Beatriz Serrano-Solano
-  - 450+ contributors
-
-coordinators:
-  - Saskia Hiltemann
-  - Bérénice Batut
-  - Helena Rasche
 
 contacts:
   - name: Saskia Hiltemann

--- a/pages/resources/glittr.md
+++ b/pages/resources/glittr.md
@@ -13,10 +13,6 @@ contributors:
   - Geert van Geest
   - Patricia Palagi
 
-coordinators:
-  - Geert van Geest
-  - Patricia Palagi
-
 contacts:
   - name: Glittr.org contact
     email: info@glittr.org

--- a/pages/resources/learning-paths.md
+++ b/pages/resources/learning-paths.md
@@ -17,14 +17,6 @@ tags: [elixir, plan, design, learning-paths, community]
 
 contributors:
   - Alexia Cardona
-  - Bérénice Batut
-  - Eva Alloza
-  - Helena Schnitzer
-  - Jessica Lindvall
-  - Loredana Le Pera
-  - Mihail Anton
-coordinators:
-  - Alexia Cardona
   - Jessica Lindvall
   - Loredana Le Pera
 contacts:

--- a/pages/resources/tess.md
+++ b/pages/resources/tess.md
@@ -9,24 +9,8 @@ description: |
 objective: |
   For training providers, TeSS provides opportunities to promote training events and news; for trainers, the portal offers an environment for sharing materials and event information; for trainees, it offers a convenient gateway via which to identify relevant training events and resources.
 
-contributors:
-  - Aitor Apaolaza
-  - Alexander Botzki
-  - Alexia Cardona
-  - Carole Goble
-  - Eva Alloza
-  - Finn Bacall
-  - Fotis Psomopoulos
-  - Hedi Peterson
-  - Ivan Kuzmin
-  - Jessica Lindvall
-  - Loredana Le Pera
-  - Melissa Burke
-  - Munazah Andrabi
-  - Olivier Sand
-  - Phil Reed
 
-coordinators:
+contributors:
   - Carole Goble
   - Finn Bacall
   - Hedi Peterson

--- a/pages/resources/tmd.md
+++ b/pages/resources/tmd.md
@@ -13,7 +13,7 @@ objective: |
     * Evaluate the longer term impact that ELIXIR-badged training events have had on the work of training participants.
 
 
-contributors: [Eleni Adamidi (GR), Brane Leskosek (SI), Nina Norgren (SE)]
+contributors: [Eleni Adamidi, Brane Leskosek, Nina Norgren]
 
 contacts:
   - name: Eleni Adamidi

--- a/pages/resources/tmd.md
+++ b/pages/resources/tmd.md
@@ -11,9 +11,9 @@ objective: |
     * Describe the audience demographic being reached by ELIXIR-badged training events
     * Assess the quality of ELIXIR-badged training events directly after they have taken place
     * Evaluate the longer term impact that ELIXIR-badged training events have had on the work of training participants.
-contributors: [Eleni Adamidi (GR), Elin Kronander (SE), Brane Leskosek (SI), Nina Norgren (SE), Mattias Nyberg (SE), Olivier Sand (FR), Samantha Wittke (FI)]
 
-coordinators: [Eleni Adamidi (GR), Brane Leskosek (SI), Nina Norgren (SE)]
+
+contributors: [Eleni Adamidi (GR), Brane Leskosek (SI), Nina Norgren (SE)]
 
 contacts:
   - name: Eleni Adamidi

--- a/pages/resources/train-the-trainer-mentorship.md
+++ b/pages/resources/train-the-trainer-mentorship.md
@@ -16,12 +16,8 @@ objective: |
 
 tags: [elixir, train-the-trainer, plan, design, develop, deliver, evaluate]
 
-# contributors: [Piv Gopalasingam (EBI), Bruna Piereck (BE), Katarzyna Kamieniecka (UK), Krzysztof Poterlowicz (UK), Helena Schnitzer (DE), Lisanna Paladin (DE), Jessica Lindvall (SE), Piv Gopalasingam (EBI), Erin Calhoun (NO), Roland Krause (LU), Katharina Heil (Hub), Daniel Wibberg (DE), Renato Alves (DE)]
-contributors: 
-  - Gil Poiares-Oliveira
-  - Allegra Via
 
-coordinators: [Allegra Via, Gil Poiares-Oliveira]
+contributors: [Allegra Via, Gil Poiares-Oliveira]
 contacts:
   - name: Allegra Via
     email: allegra.via@uniroma1.it

--- a/pages/resources/train-the-trainer.md
+++ b/pages/resources/train-the-trainer.md
@@ -9,10 +9,9 @@ description: |
 objective: |
   The programme objective is to give instructors tools and tips for providing an enriching learning experience to trainees, irrespective of topic, and to include best-practice guidance on course and training material development. 
 
-# contributors: [Piv Gopalasingam (EBI), Bruna Piereck (BE), Katarzyna Kamieniecka (UK), Krzysztof Poterlowicz (UK), Helena Schnitzer (DE), Lisanna Paladin (DE), Jessica Lindvall (SE), Piv Gopalasingam (EBI), Erin Calhoun (NO), Roland Krause (LU), Katharina Heil (Hub), Daniel Wibberg (DE), Renato Alves (DE)]
-contributors: 
 
-coordinators: [Allegra Via (IT), Krzysztof Poterlowicz (UK), Lisanna Paladin (DE), Patricia Palagi (CH)]
+
+contributors: [Allegra Via (IT), Krzysztof Poterlowicz (UK), Lisanna Paladin (DE), Patricia Palagi (CH)]
 contacts:
   - name: Allegra Via
     mail: allegra.via@uniroma1.it

--- a/pages/resources/train-the-trainer.md
+++ b/pages/resources/train-the-trainer.md
@@ -11,14 +11,14 @@ objective: |
 
 
 
-contributors: [Allegra Via (IT), Krzysztof Poterlowicz (UK), Lisanna Paladin (DE), Patricia Palagi (CH)]
+contributors: [Allegra Via, Krzysztof Poterlowicz, Lisanna Paladin, Patricia Palagi]
 contacts:
   - name: Allegra Via
-    mail: allegra.via@uniroma1.it
+    email: allegra.via@uniroma1.it
   - name: Krzysztof Poterlowicz 
-    mail: K.Poterlowicz1@bradford.ac.uk
+    email: K.Poterlowicz1@bradford.ac.uk
   - name: Lisanna Paladin
-    mail: lisanna.paladin@embl.de
+    email: lisanna.paladin@embl.de
   - name: Patricia Palagi
     email: Patricia.Palagi@sib.swiss
 


### PR DESCRIPTION
The contributors listed on the SPLASH contributors page should be ppl who contributed to SPLASH and not to the Resources listed on SPLASH. 


**Template and Layout Adjustments:**

* Removed the inclusion of `contributor-minitiles-page.html` from the resource page layout,
* Removed listed contributors from each resource page
* Renamed the coordinators to contributors in order for ppl contributing a resource to SPLASH to be automatically listed on the contributors page


**Contact Information Fix:**
The mailto link did not work properly on the TtT-page but was fixed
* Standardized the contact information fields, ensuring all email addresses use the `email` key instead of `mail`.

Adressess part of #289 
