### PR TITLE
Added correct funder logo to the Learning Paths resource

### DIFF
--- a/pages/resources/learning-paths.md
+++ b/pages/resources/learning-paths.md
@@ -31,7 +31,7 @@ contacts:
 mailingList: https://signup.aai.lifescience-ri.eu/registrar/?vo=elixir&group=Community%3ATraining
 funding:
   - name: ELIXIR
-    logo: funder_example_1_logo.png
+    logo: elixir-logo.png
     url: https://elixir-europe.org/ 
 logo:
 ---


### PR DESCRIPTION
Small addition to #94 and #274 to correct the logo for the Learning Paths resource funding.