### PR TITLE
remove numbers from front page

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,4 +19,3 @@ sidebar: false
     </div>
 </div>
 
-{% include index/splash-in-numbers.html %}


### PR DESCRIPTION
I have just removed the inclusion of the numbers on the front page. The underlying code is still present. To have a clean repo we might want to remove it completly?